### PR TITLE
[Fix] 일기 리스트에서 보이는 글자 제한

### DIFF
--- a/frontend/src/components/DiaryCom.js
+++ b/frontend/src/components/DiaryCom.js
@@ -23,7 +23,7 @@ function DiaryCom({ diaryId, diaryContent, diarySentiment, diaryCreated, handleS
                             <h5>{diaryCreated}</h5>
                             <button className="delBtn" type="submit" onClick={() => handleSubmit(diaryId)}>❌</button></div>
                         <div className="content">
-                            <span>{diaryContent}</span>
+                            <span>{diaryContent.length > 50 ? diaryContent.substr(0, 50) + "..." : diaryContent}</span>
                         </div>
                         <div className="flex">
                             <div className="sentiment">


### PR DESCRIPTION
글자가 너무 길어지면 리스트에서 볼 때도 계속 늘어나는 문제가 생겨 50자 이내로만 보이도록 수정하고 나머지는 ... 처리 후 더 보기를 통해 보도록 유도